### PR TITLE
check_output encoding instead of manual .decode()

### DIFF
--- a/git_hook_utilities.py
+++ b/git_hook_utilities.py
@@ -41,7 +41,7 @@ def get_hooks_conf():
     """
     # NOTE: Change to HOOKS_CONF to LOCAL_HOOKS_CONF when testing
     cmd = "git archive --remote=" + HOOKS_CONF + " HEAD hooks.conf | tar -x"
-    subprocess.check_output(cmd, shell=True, cwd="/tmp")
+    subprocess.check_output(cmd, shell=True, cwd="/tmp", encoding='UTF-8')
     if path.exists("/tmp/hooks.conf"):
         with open("/tmp/hooks.conf") as f:
             txt = f.read()

--- a/prevent_bad_version_numbers.py
+++ b/prevent_bad_version_numbers.py
@@ -38,7 +38,7 @@ def git_diff(oldrev, newrev, fname):
     diff = subprocess.check_output(["git",
                                     "diff",
                                     oldrev + ".." + newrev,
-                                    "--", fname])
+                                    "--", fname], encoding='UTF-8')
     return diff.splitlines()
 
 
@@ -46,7 +46,7 @@ def git_diff_pre_commit(fname):
     """Git diff for a pre-commit hook."""
     diff = subprocess.check_output(["git",
                                     "diff",
-                                    "--cached", fname])
+                                    "--cached", fname], encoding='UTF-8')
     return diff.splitlines()
 
 
@@ -55,18 +55,18 @@ def git_diff_files(oldrev, newrev):
     files_modified = subprocess.check_output(["git",
                                               "diff",
                                               "--name-only",
-                                              oldrev + ".." + newrev])
+                                              oldrev + ".." + newrev], encoding='UTF-8' )
     return files_modified.splitlines()
 
 
 def get_version_bump(diff):
     """Get the version bumps in DESCRIPTION file."""
-    prev_version = [line.decode().replace("-Version:", "")
+    prev_version = [line.replace("-Version:", "")
                     for line in diff
-                    if line.decode().startswith("-Version")]
-    new_version = [line.decode().replace("+Version:", "")
+                    if line.startswith("-Version")]
+    new_version = [line.replace("+Version:", "")
                    for line in diff
-                   if line.decode().startswith("+Version")]
+                   if line.startswith("+Version")]
     # If versions are equal, no version change
     if prev_version == new_version:
         return None, None
@@ -149,7 +149,7 @@ def prevent_bad_version_numbers(oldrev, newrev, refname):
         oldrev = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
     files_modified = git_diff_files(oldrev, newrev)
     for fname in files_modified:
-        if "DESCRIPTION" in fname.decode():
+        if "DESCRIPTION" in fname:
             diff = git_diff(oldrev, newrev, fname)
             prev_version, new_version = get_version_bump(diff)
             if (prev_version is None) and (new_version is None):

--- a/prevent_duplicate_commits.py
+++ b/prevent_duplicate_commits.py
@@ -39,8 +39,8 @@ to see body of commits.
 
 
 def get_svn_revision(commit):
-    body = subprocess.check_output(["git", "show", "--format=%b", commit])
-    revision = SVN_COMMIT_REGEX.match(body.decode())
+    body = subprocess.check_output(["git", "show", "--format=%b", commit], encoding='UTF-8')
+    revision = SVN_COMMIT_REGEX.match(body)
     if revision is not None:
         revision = revision.group(1)
     return revision
@@ -51,11 +51,11 @@ def prevent_duplicate_commits(oldrev, newrev, refname):
     try:
         commit_list = subprocess.check_output([
             "git", "rev-list", newrev, "-n", GIT_COMMIT_LIST_LENGTH
-        ])
+        ], encoding='UTF-8')
     except Exception as e:
         print("Exception: %s" % e)
         pass
-    commit_list = commit_list.decode().split("\n")
+    commit_list = commit_list.split("\n")
     commit_list = [item for item in commit_list if len(item) > 0]
 
     # For each of the first GIT_COMMIT_LIST_LENGTH pairs, check diff
@@ -66,7 +66,7 @@ def prevent_duplicate_commits(oldrev, newrev, refname):
         rev1 = get_svn_revision(first)
         rev2 = get_svn_revision(second)
         if rev1 and (rev1 == rev2):
-            diff = subprocess.check_output(["git", "diff", first, second])
+            diff = subprocess.check_output(["git", "diff", first, second], encoding='UTF-8')
             # If the diff of two commits is empty, means they are the same.
             # i.e duplicate
             if not diff:

--- a/prevent_large_files.py
+++ b/prevent_large_files.py
@@ -28,24 +28,24 @@ def prevent_large_files(oldrev, newrev, refname):
         if refname == "refs/heads/master":
             oldrev = subprocess.check_output([
                 "git", "rev-list", "--max-parents=0", newrev
-            ]).split().pop().strip()
+            ], encoding='UTF-8').split().pop().strip()
         else:
             oldrev = "HEAD"
 
     list_files = subprocess.check_output(["git", "diff",
                                           "--name-only",
                                           "--diff-filter=ACMRT",
-                                          oldrev + ".." + newrev])
+                                          oldrev + ".." + newrev], encoding='UTF-8')
     for fl in list_files.splitlines():
 
         size = subprocess.check_output(["git", "cat-file", "-s",
-                                        newrev + ":" + fl.decode()])
+                                        newrev + ":" + fl], encoding='UTF-8')
         #  Check to see if for some reason we didn't get a size
         size = int(size.strip())
         if size:
             # Compare filesize to MAXSIZE
             mb = 1024.0 * 1024.0
             if size > MAXSIZE:
-                print(ERROR_MSG % (MAXSIZE / mb, fl.decode(), size / mb))
+                print(ERROR_MSG % (MAXSIZE / mb, fl, size / mb))
                 sys.exit(1)
     return

--- a/prevent_merge_markers.py
+++ b/prevent_merge_markers.py
@@ -92,7 +92,7 @@ def prevent_merge_markers(oldrev, newrev, refname):
     # Get diff
     diff = subprocess.check_output(['git',
                                     'diff',
-                                    oldrev + ".." + newrev])
+                                    oldrev + ".." + newrev], encoding='UTF-8')
     conflicts = pattern_match(diff)
     # If there are conflicts in string
     if conflicts:

--- a/rss_feed.py
+++ b/rss_feed.py
@@ -37,10 +37,10 @@ def rss_feed(oldrev, newrev, refname, length):
         latest_commit = subprocess.check_output([
             "git", "log", oldrev + ".." + newrev,
             "--pretty=format:%H|%an|%ae|%ai"
-        ])
+        ], encoding='UTF-8')
         # Get package name
         package_path = subprocess.check_output([
-            "git", "rev-parse", "--absolute-git-dir"]).strip()
+            "git", "rev-parse", "--absolute-git-dir"], encoding='UTF-8').strip()
         package_name = basename(abspath(package_path)).replace(".git", "")
     except Exception as err:
         logging.error("Exception: %s" % err)
@@ -53,7 +53,7 @@ def rss_feed(oldrev, newrev, refname, length):
             commit_id, author, email, timestamp = commit.split("|")
             commit_msg = subprocess.check_output(["git", "log",
                                                   "--pretty=format:%B",
-                                                  "-n", "1", commit_id])
+                                                  "-n", "1", commit_id], encoding='UTF-8')
             # link for correct branch
             if "RELEASE" in refname:
                 link = package_name
@@ -150,7 +150,7 @@ if False:
     refname = None
     revs = subprocess.check_output([
         "git", "log", "-2", "--format=%H"
-    ]).splitlines()
+    ], encoding='UTF-8').splitlines()
     newrev = revs[0].strip()
     oldrev = revs[1].strip()
     rss_feed(oldrev, newrev, refname, 5)


### PR DESCRIPTION
P.S. not tested

This should hopefully fix the byte string types across the board, assuming i didn't miss any.
Alternative would be to use `getoutput` instead of `check_output`.
xref https://stackoverflow.com/questions/18244126/python3-subprocess-output